### PR TITLE
Adding tocs for the next round

### DIFF
--- a/cup.json
+++ b/cup.json
@@ -99,14 +99,20 @@
   },
   "groupStages": {
     "0": {
+      "team1": "vt",
+      "team2": "aw",
       "startDate": 0,
       "tweetId": null
     },
     "1": {
+      "team1": "ln",
+      "team2": "cs",
       "startDate": 0,
       "tweetId": null
     },
     "2": {
+      "team1": "sr",
+      "team2": "es",
       "startDate": 0,
       "tweetId": null
     },

--- a/cup.json
+++ b/cup.json
@@ -28,19 +28,19 @@
       "team1": "gc",
       "team2": "sr",
       "startDate": "2021-01-19",
-      "tweetId": null
+      "tweetId": "1351455148695027718"
     },
     "5": {
       "team1": "es",
       "team2": "cr",
       "startDate": "2021-01-20",
-      "tweetId": null
+      "tweetId": "1351819249237561345"
     },
     "6": {
       "team1": "xc",
       "team2": "tl",
       "startDate": "2021-01-21",
-      "tweetId": null
+      "tweetId": "1352183163234246656"
     },
     "7": {
       "team1": "gn",
@@ -112,6 +112,7 @@
     },
     "2": {
       "team1": "sr",
+      "team2": "es",
       "startDate": 0,
       "tweetId": null
     },

--- a/cup.json
+++ b/cup.json
@@ -112,7 +112,6 @@
     },
     "2": {
       "team1": "sr",
-      "team2": "es",
       "startDate": 0,
       "tweetId": null
     },


### PR DESCRIPTION
Adds the TOCs who have won their first rounds. Assumes the bracket stays in the same order and doesn't get shuffled for the round of 16